### PR TITLE
Problem: timeout of SENDMAIL protocol on busy system

### DIFF
--- a/include/fty_email_server.h
+++ b/include/fty_email_server.h
@@ -78,6 +78,9 @@ extern "C" {
 //  REP: subject=SENDMAIL-ERR [$uuid|$error code|$error message]
 //      if email wasn't sent, or there was improper number of arguments
 //      error message comes from msmtp stderr and is NOT normalized!
+//
+//  args:
+//      "sendmail-only"      : ignore consumer/ part, connect as $(malamute/address)-sendmail
 FTY_EMAIL_EXPORT void
    fty_email_server (zsock_t *pipe, void* args);
 

--- a/src/fty_email.cc
+++ b/src/fty_email.cc
@@ -188,15 +188,20 @@ int main (int argc, char** argv)
 
     if (verbose)
         puts ("START fty-email - Daemon that is responsible for email notification about alerts");
+
     zactor_t *smtp_server = zactor_new (fty_email_server, (void *) NULL);
     if ( !smtp_server ) {
         zsys_error ("cannot start the daemon");
         return -1;
     }
 
+    // create new actor with "sendmail-only" argument here
+
     if (verbose)
         zstr_sendx (smtp_server, "VERBOSE", NULL);
     zstr_sendx (smtp_server, "LOAD", config_file, NULL);
+
+    // configure it here
 
     zloop_t *send_alert_trigger = zloop_new();
     // as 5 minutes is the smallest possible reaction time

--- a/src/fty_email_server.cc
+++ b/src/fty_email_server.cc
@@ -543,6 +543,7 @@ fty_email_encode (
 void
 fty_email_server (zsock_t *pipe, void* args)
 {
+    // bool sendmail_only = (args && streq (args, "sendmail-only"));
     bool verbose = false;
     char* name = NULL;
     char *endpoint = NULL;
@@ -675,6 +676,8 @@ fty_email_server (zsock_t *pipe, void* args)
                         endpoint = strdup (zconfig_get (config, "malamute/endpoint", NULL));
                         zstr_free (&name);
                         name = strdup (zconfig_get (config, "malamute/address", NULL));
+                        // if (sendmail_only)
+                        //      add -sendmail to address
                         uint32_t timeout = 1000;
                         sscanf ("%" SCNu32, zconfig_get (config, "malamute/timeout", "1000"), &timeout);
 
@@ -689,6 +692,7 @@ fty_email_server (zsock_t *pipe, void* args)
                         zsys_warning ("(agent-smtp): malamute/endpoint or malamute/address not in configuration, NOT connected to the broker!");
                 }
 
+                // skip if sendmail_only is true
                 if (zconfig_locate (config, "malamute/consumers")) {
                     if (mlm_client_connected (client)) {
                         zconfig_t *consumers = zconfig_locate (config, "malamute/consumers");


### PR DESCRIPTION
Solution: add "sendmail-only" argument to server, so it will not
subscribe to streams in such case

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>