### PR TITLE
Problem: Debian packaging fails to get some manpages

### DIFF
--- a/packaging/debian/fty-email.manpages
+++ b/packaging/debian/fty-email.manpages
@@ -1,2 +1,2 @@
-usr/share/man/man1/fty-email.1
-usr/share/man/man1/fty-sendmail.1
+debian/tmp/usr/share/man/man1/fty-email.1
+debian/tmp/usr/share/man/man1/fty-sendmail.1

--- a/packaging/debian/libfty-email-dev.manpages
+++ b/packaging/debian/libfty-email-dev.manpages
@@ -1,2 +1,2 @@
-usr/share/man/man3/*
-usr/share/man/man7/*
+debian/tmp/usr/share/man/man3/*
+debian/tmp/usr/share/man/man7/*


### PR DESCRIPTION
Solution: Modify paths in Debian packaging files
The best solution would be to use debian/compat 11, since dh_installman could
by itself find manpages in debian/tmp at packaging time. However, Debian 8
Jessie only support 10 as the highest compatibility level

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>