### PR TITLE
[M/M] Problem: Alarm descriptions in alarm e-mails are not translated.

### DIFF
--- a/src/emailconfiguration.cc
+++ b/src/emailconfiguration.cc
@@ -92,7 +92,10 @@ s_generateEmailBodyResolved (fty_proto_t *alert, const std::string& extname)
     zstr_free (&result_char);
     result = replace_tokens (result, "__rulename__", fty_proto_rule (alert));
     result = replace_tokens (result, "__assetname__", extname);
-    result = replace_tokens (result, "__description__", fty_proto_description (alert));
+    char *description_char = translation_get_translated_text (fty_proto_description (alert));
+    std::string description (description_char);
+    zstr_free (&description_char);
+    result = replace_tokens (result, "__description__", description.c_str ());
     return result;
 }
 
@@ -104,7 +107,10 @@ s_generateEmailBodyActive (fty_proto_t *alert, const std::string& priority, cons
     zstr_free (&result_char);
     result = replace_tokens (result, "__rulename__", fty_proto_rule (alert));
     result = replace_tokens (result, "__assetname__", extname);
-    result = replace_tokens (result, "__description__", fty_proto_description (alert));
+    char *description_char = translation_get_translated_text (fty_proto_description (alert));
+    std::string description (description_char);
+    zstr_free (&description_char);
+    result = replace_tokens (result, "__description__", description.c_str ());
     result = replace_tokens (result, "__priority__", priority);
     result = replace_tokens (result, "__severity__", fty_proto_severity (alert));
     result = replace_tokens (result, "__state__", fty_proto_state (alert));
@@ -130,7 +136,10 @@ s_generateEmailSubjectActive (fty_proto_t *alert, const std::string& priority, c
     zstr_free (&result_char);
     result = replace_tokens (result, "__rulename__", fty_proto_rule (alert));
     result = replace_tokens (result, "__assetname__", extname);
-    result = replace_tokens (result, "__description__", fty_proto_description (alert));
+    char *description_char = translation_get_translated_text (fty_proto_description (alert));
+    std::string description (description_char);
+    zstr_free (&description_char);
+    result = replace_tokens (result, "__description__", description.c_str ());
     result = replace_tokens (result, "__priority__", priority);
     result = replace_tokens (result, "__severity__", fty_proto_severity (alert));
     result = replace_tokens (result, "__state__", fty_proto_state (alert));

--- a/src/fty_email_server.cc
+++ b/src/fty_email_server.cc
@@ -595,8 +595,9 @@ fty_email_server_test (bool verbose)
         //      1. send alert message
         zlist_t *actions = zlist_new ();
         zlist_append (actions, (void *) "EMAIL");
+        std::string description ("{ \"key\": \"Device {{var1}} does not provide expected data. It may be offline or not correctly configured.\", \"variables\": { \"var1\": \"ASSET1\" } }");
         zmsg_t *msg = fty_proto_encode_alert (NULL, zclock_time ()/1000, 600, "NY_RULE", asset_name, \
-                                      "ACTIVE","CRITICAL","ASDFKLHJH", actions);
+                                      "ACTIVE","CRITICAL",description.c_str (), actions);
         assert (msg);
 
         zuuid_t *zuuid = zuuid_new ();
@@ -649,7 +650,7 @@ fty_email_server_test (bool verbose)
         // expected string without date
         std::string expectedBody = "From:bios@eaton.com\nTo: scenario1.email@eaton.com\nSubject: CRITICAL alert on ASSET1 from the rule ny_rule is active!\n\n"
         "In the system an alert was detected.\nSource rule: ny_rule\nAsset: ASSET1\nAlert priority: P1\nAlert severity: CRITICAL\n"
-        "Alert description: ASDFKLHJH\nAlert state: ACTIVE\n";
+        "Alert description: Device ASSET1 does not provide expected data. It may be offline or not correctly configured.\nAlert state: ACTIVE\n";
         expectedBody.erase(remove_if(expectedBody.begin(), expectedBody.end(), isspace), expectedBody.end());
 
 
@@ -670,8 +671,9 @@ fty_email_server_test (bool verbose)
         //      1. send alert message
         zlist_t *actions = zlist_new ();
         zlist_append (actions, (void *) "EMAIL");
+        std::string description ("{ \"key\": \"Device {{var1}} does not provide expected data. It may be offline or not correctly configured.\", \"variables\": { \"var1\": \"ASSET1\" } }");
         zmsg_t *msg = fty_proto_encode_alert (NULL, time (NULL), 600, "NY_RULE", asset_name1, \
-                                      "ACTIVE","CRITICAL","ASDFKLHJH", actions);
+                                      "ACTIVE","CRITICAL",description.c_str (), actions);
         assert (msg);
 
         zuuid_t *zuuid = zuuid_new ();
@@ -712,8 +714,9 @@ fty_email_server_test (bool verbose)
         const char *asset_name = "ASSET3";
         zlist_t *actions = zlist_new ();
         zlist_append (actions, (void *) "EMAIL");
+        std::string description ("{ \"key\": \"Device {{var1}} does not provide expected data. It may be offline or not correctly configured.\", \"variables\": { \"var1\": \"ASSET1\" } }");
         zmsg_t *msg = fty_proto_encode_alert (NULL, time (NULL), 600, "NY_RULE", asset_name, \
-                                      "ACTIVE","CRITICAL","ASDFKLHJH", actions);
+                                      "ACTIVE","CRITICAL",description.c_str (), actions);
         assert (msg);
 
         zuuid_t *zuuid = zuuid_new ();
@@ -752,8 +755,9 @@ fty_email_server_test (bool verbose)
         const char *asset_name = "ASSET3";
         zlist_t *actions = zlist_new ();
         zlist_append (actions, (void *) "EMAIL");
+        std::string description ("{ \"key\": \"Device {{var1}} does not provide expected data. It may be offline or not correctly configured.\", \"variables\": { \"var1\": \"ASSET1\" } }");
         zmsg_t *msg = fty_proto_encode_alert (NULL, time (NULL), 600, "NY_RULE", asset_name, \
-                                      "ACTIVE","CRITICAL","ASDFKLHJH", actions);
+                                      "ACTIVE","CRITICAL",description.c_str (), actions);
         assert (msg);
 
         zuuid_t *zuuid = zuuid_new ();
@@ -794,8 +798,9 @@ fty_email_server_test (bool verbose)
         //      1. send alert message
         zlist_t *actions = zlist_new ();
         zlist_append (actions, (void *) "SMS");
-        zmsg_t *msg = fty_proto_encode_alert (NULL, zclock_time ()/1000, 600, "NY_RULE", asset_name, \
-                                      "ACTIVE","CRITICAL","ASDFKLHJH", actions);
+        std::string description ("{ \"key\": \"Device {{var1}} does not provide expected data. It may be offline or not correctly configured.\", \"variables\": { \"var1\": \"ASSET1\" } }");
+        zmsg_t *msg = fty_proto_encode_alert (NULL, zclock_time()/1000, 600, "NY_RULE", asset_name, \
+                                      "ACTIVE","CRITICAL",description.c_str (), actions);
         assert (msg);
 
         zuuid_t *zuuid = zuuid_new ();

--- a/src/selftest-ro/test_en_US.json
+++ b/src/selftest-ro/test_en_US.json
@@ -1,4 +1,5 @@
 {
 "In the system an alert was detected.\nSource rule: {{var1}}\nAsset: {{var2}}\nAlert priority: P{{var3}}\nAlert severity: {{var4}}\nAlert description: {{var5}}\nAlert state: {{var6}}" : "In the system an alert was detected.\nSource rule: {{var1}}\nAsset: {{var2}}\nAlert priority: P{{var3}}\nAlert severity: {{var4}}\nAlert description: {{var5}}\nAlert state: {{var6}}",
 "{{var1}} alert on {{var2}}\nfrom the rule {{var3}} is active!" : "{{var1}} alert on{{var2}}\nfrom the rule {{var3}} is active!"
+"Device {{var1}} does not provide expected data. It may be offline or not correctly configured." : "Device {{var1}} does not provide expected data. It may be offline or not correctly configured."
 }

--- a/src/selftest-ro/test_en_US.json
+++ b/src/selftest-ro/test_en_US.json
@@ -1,5 +1,5 @@
 {
 "In the system an alert was detected.\nSource rule: {{var1}}\nAsset: {{var2}}\nAlert priority: P{{var3}}\nAlert severity: {{var4}}\nAlert description: {{var5}}\nAlert state: {{var6}}" : "In the system an alert was detected.\nSource rule: {{var1}}\nAsset: {{var2}}\nAlert priority: P{{var3}}\nAlert severity: {{var4}}\nAlert description: {{var5}}\nAlert state: {{var6}}",
-"{{var1}} alert on {{var2}}\nfrom the rule {{var3}} is active!" : "{{var1}} alert on{{var2}}\nfrom the rule {{var3}} is active!"
+"{{var1}} alert on {{var2}}\nfrom the rule {{var3}} is active!" : "{{var1}} alert on{{var2}}\nfrom the rule {{var3}} is active!",
 "Device {{var1}} does not provide expected data. It may be offline or not correctly configured." : "Device {{var1}} does not provide expected data. It may be offline or not correctly configured."
 }


### PR DESCRIPTION
Solution: Add calls to translation_get_translated_text (), update tests.

Signed-off-by: Jana Rapava <JanaRapava@eaton.com>
***************************************************************
This PR depends on https://github.com/42ity/fty-common-translation/pull/17