### PR TITLE
(S/M) Problem: Fty-email doesn't check for language on config file change.

### DIFF
--- a/include/fty_email.h
+++ b/include/fty_email.h
@@ -26,9 +26,10 @@
 #include "fty_email_library.h"
 
 //  Add your own public definitions here, if you need them
-#define FTY_EMAIL_ADDRESS  "fty-email"
-#define FTY_EMAIL_ADDRESS_SENDMAIL_ONLY  "fty-email-sendmail-only"
-#define FTY_EMAIL_ENDPOINT "ipc://@/malamute"
-#define FTY_EMAIL_CONFIG_FILE "/etc/fty-email/fty-email.cfg"
-#define DEFAULT_LOG_CONFIG "/etc/fty/ftylog.cfg"
+#define FTY_EMAIL_ADDRESS               "fty-email"
+#define FTY_EMAIL_ADDRESS_SENDMAIL_ONLY "fty-email-sendmail-only"
+#define FTY_EMAIL_ENDPOINT              "ipc://@/malamute"
+#define FTY_EMAIL_CONFIG_FILE           "/etc/fty-email/fty-email.cfg"
+#define DEFAULT_LOG_CONFIG              "/etc/fty/ftylog.cfg"
+#define DEFAULT_LANGUAGE                "en_US"
 #endif

--- a/src/fty_email.cc
+++ b/src/fty_email.cc
@@ -32,7 +32,6 @@
 
 #define TRANSLATION_ROOT    "/usr/share/etn-translations"
 #define TRANSLATION_PREFIX  "locale_"
-#define DEFAULT_LANGUAGE    "en_US"
 
 // hack to allow reload of config file w/o the need to rewrite server to zloop and reactors
 char *config_file = NULL;

--- a/src/fty_email_server.cc
+++ b/src/fty_email_server.cc
@@ -134,6 +134,7 @@ fty_email_server (zsock_t *pipe, void* args)
     char *test_reader_name = NULL;
     char *sms_gateway = NULL;
     char *gw_template = NULL;
+    char *language = NULL;
 
     mlm_client_t *test_client = NULL;
     mlm_client_t *client = mlm_client_new ();
@@ -175,6 +176,12 @@ fty_email_server (zsock_t *pipe, void* args)
                     break;
                 }
 
+                if (s_get (config, "server/language", DEFAULT_LANGUAGE)) {
+                    language = strdup (s_get (config, "server/language", DEFAULT_LANGUAGE));
+                    int rv = translation_change_language (language);
+                    if (rv != TE_OK)
+                        log_warning ("Language not changed to %s, continuing in %s", language, DEFAULT_LANGUAGE);
+                }
                 // SMS_GATEWAY
                 if (s_get (config, "smtp/smsgateway", NULL)) {
                     sms_gateway = strdup (s_get (config, "smtp/smsgateway", NULL));
@@ -443,6 +450,7 @@ fty_email_server (zsock_t *pipe, void* args)
     zstr_free (&test_reader_name);
     zstr_free (&sms_gateway);
     zstr_free (&gw_template);
+    zstr_free (&language);
     zpoller_destroy (&poller);
     mlm_client_destroy (&client);
     mlm_client_destroy (&test_client);


### PR DESCRIPTION
Solution: Do it, load new language.

Signed-off-by: Jana Rapava <janarapava@eaton.com>