### PR TITLE
Problem: We know and track the SMTP port, but do not use it

### DIFF
--- a/src/email.cc
+++ b/src/email.cc
@@ -102,6 +102,7 @@ std::string Smtp::createConfigFile() const
 
     line += "account default\n";
     line += "host " + _host +"\n";
+    line += "port " + _port +"\n";
     line += "from " + _from + "\n";
     ssize_t r = write (handle,  line.c_str(), line.size());
     if (r > 0 && (size_t) r != line.size ())


### PR DESCRIPTION
Solution: Put it into msmtp client config

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>