### PR TITLE
Problem: Enctryption is spelled differently

### DIFF
--- a/src/email.cc
+++ b/src/email.cc
@@ -44,7 +44,7 @@ Smtp::Smtp():
     _host {},
     _port { "25" },
     _from { "EatonProductFeedback@eaton.com" },
-    _encryption { Enctryption::NONE },
+    _encryption { Encryption::NONE },
     _username {},
     _password {},
     _msmtp { "/usr/bin/msmtp" },
@@ -77,15 +77,15 @@ std::string Smtp::createConfigFile() const
     const std::string verify_ca = _verify_ca ? "on" : "off";
 
     switch (_encryption) {
-    case Enctryption::NONE:
+    case Encryption::NONE:
         line += "tls off\n"
                 "tls_starttls off\n";
         break;
-    case Enctryption::TLS:
+    case Encryption::TLS:
         line += "tls on\n"
                 "tls_certcheck " + verify_ca + "\n";
         break;
-    case Enctryption::STARTTLS:
+    case Encryption::STARTTLS:
         // TODO: check if this is correct!
         line += "tls off\n"
                 "tls_certcheck " + verify_ca + "\n"
@@ -119,9 +119,9 @@ void Smtp::deleteConfigFile(std::string &filename) const
 
 void Smtp::encryption(std::string enc)
 {
-    if( strcasecmp ("starttls", enc.c_str()) == 0) encryption (Enctryption::STARTTLS);
-    if( strcasecmp ("tls", enc.c_str()) == 0) encryption (Enctryption::TLS);
-    encryption (Enctryption::NONE);
+    if( strcasecmp ("starttls", enc.c_str()) == 0) encryption (Encryption::STARTTLS);
+    if( strcasecmp ("tls", enc.c_str()) == 0) encryption (Encryption::TLS);
+    encryption (Encryption::NONE);
 }
 
 void Smtp::sendmail(

--- a/src/email.h
+++ b/src/email.h
@@ -52,7 +52,7 @@ Example:
  *
  * Security of SMTP connection
  */
-enum class Enctryption {
+enum class Encryption {
     NONE,
     TLS,
     STARTTLS
@@ -126,7 +126,7 @@ class Smtp
 
         /** \brief set the encryption for SMTP communication (NONE|TLS|STARTTLS) */
         void encryption (std::string enc);
-        void encryption (Enctryption enc) { _encryption = enc; };
+        void encryption (Encryption enc) { _encryption = enc; };
 
         /** \brief turn on or of the CA verification */
         void verify_ca (bool verify) { _verify_ca = verify; }
@@ -217,7 +217,7 @@ class Smtp
         std::string _host;
         std::string _port;
         std::string _from;
-        Enctryption _encryption;
+        Encryption _encryption;
         std::string _username;
         std::string _password;
         std::string _msmtp;


### PR DESCRIPTION
Solution: Fix it

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

PS: I grepped 42ity sources, nothing beside fty-email refers to the string so it seems safe to change.